### PR TITLE
shortened binary name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,10 @@ license = "MIT"
 description = "Simple CLI password generator. Can also be used as lib in other porjects"
 repository = "https://github.com/CCecilia/simple_password_generator"
 
+[[bin]]
+name = "spg"
+path = "src/main.rs"
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 Running from the binary file
 
 ```bash
-$ ./simple_password_generator --length 16
+$ ./spg --length 16
 ```
 
 ```bash


### PR DESCRIPTION
## Describe your changes
Updated cargo.toml to use a different for the generated binary

## Issue ticket number and link
[10 shorten bin name](https://github.com/CCecilia/simple_password_generator/issues/10)

## Checklist before requesting a review
- [x ] I have performed a self-review of my code